### PR TITLE
Update default TLS profile to Chrome146, add new identifiers

### DIFF
--- a/src/TlsClient.Core/BaseTlsClient.cs
+++ b/src/TlsClient.Core/BaseTlsClient.cs
@@ -19,7 +19,7 @@ namespace TlsClient.Core
             Options = options ?? throw new ArgumentNullException(nameof(options));
         }
 
-        protected BaseTlsClient(): this(new TlsClientOptions(TlsClientIdentifier.Chrome132, "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36 OPR/117.0.0.0")){}
+        protected BaseTlsClient(): this(new TlsClientOptions(TlsClientIdentifier.Default, "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36")){}
 
         public abstract Response Request(Request request);
         public abstract GetCookiesFromSessionResponse GetCookies(string url);

--- a/src/TlsClient.Core/Models/Entities/TlsClientIdentifier.cs
+++ b/src/TlsClient.Core/Models/Entities/TlsClientIdentifier.cs
@@ -3,6 +3,8 @@
     // Reference: https://github.com/bogdanfinn/tls-client/blob/master/profiles/profiles.go
     public sealed class TlsClientIdentifier
     {
+        public static TlsClientIdentifier Default => Chrome146;
+
         #region Chrome Profiles
         public static readonly TlsClientIdentifier Chrome103 = new TlsClientIdentifier("chrome_103");
         public static readonly TlsClientIdentifier Chrome104 = new TlsClientIdentifier("chrome_104");
@@ -21,12 +23,18 @@
         public static readonly TlsClientIdentifier Chrome124 = new TlsClientIdentifier("chrome_124");
         public static readonly TlsClientIdentifier Chrome130Psk = new TlsClientIdentifier("chrome_130_PSK");
         public static readonly TlsClientIdentifier Chrome131 = new TlsClientIdentifier("chrome_131");
-        public static readonly TlsClientIdentifier Chrome132 = new TlsClientIdentifier("chrome_132");
         public static readonly TlsClientIdentifier Chrome131Psk = new TlsClientIdentifier("chrome_131_PSK");
         public static readonly TlsClientIdentifier Chrome133 = new TlsClientIdentifier("chrome_133");
         public static readonly TlsClientIdentifier Chrome133Psk = new TlsClientIdentifier("chrome_133_PSK");
         public static readonly TlsClientIdentifier Chrome144 = new TlsClientIdentifier("chrome_144");
         public static readonly TlsClientIdentifier Chrome144Psk = new TlsClientIdentifier("chrome_144_PSK");
+        public static readonly TlsClientIdentifier Chrome146 = new TlsClientIdentifier("chrome_146");
+        public static readonly TlsClientIdentifier Chrome146Psk = new TlsClientIdentifier("chrome_146_PSK");
+        #endregion
+
+        #region Brave Profiles
+        public static readonly TlsClientIdentifier Brave146 = new TlsClientIdentifier("brave_146");
+        public static readonly TlsClientIdentifier Brave146Psk = new TlsClientIdentifier("brave_146_PSK");
         #endregion
 
         #region Safari Profiles
@@ -39,6 +47,7 @@
         public static readonly TlsClientIdentifier SafariIos170 = new TlsClientIdentifier("safari_ios_17_0");
         public static readonly TlsClientIdentifier SafariIos180 = new TlsClientIdentifier("safari_ios_18_0");
         public static readonly TlsClientIdentifier SafariIos185 = new TlsClientIdentifier("safari_ios_18_5");
+        public static readonly TlsClientIdentifier SafariIos260 = new TlsClientIdentifier("safari_ios_26_0");
         #endregion
 
         #region Firefox Profiles
@@ -57,6 +66,7 @@
         public static readonly TlsClientIdentifier Firefox146Psk = new TlsClientIdentifier("firefox_146_PSK");
         public static readonly TlsClientIdentifier Firefox147 = new TlsClientIdentifier("firefox_147");
         public static readonly TlsClientIdentifier Firefox147Psk = new TlsClientIdentifier("firefox_147_PSK");
+        public static readonly TlsClientIdentifier Firefox148Psk = new TlsClientIdentifier("firefox_148_PSK");
         #endregion
 
         #region Opera Profiles

--- a/tests/TlsClient.Api.Tests/BodyTests.cs
+++ b/tests/TlsClient.Api.Tests/BodyTests.cs
@@ -18,7 +18,7 @@ namespace TlsClient.Api.Tests
         [Fact]
         public void Should_Download_Image()
         {
-            using var tlsClient = new ApiTlsClient(new Uri("http://127.0.0.1:8080"), "my-auth-key-1");
+            using var tlsClient = new ApiTlsClient(new Uri("http://127.0.0.1:5666"), "my-auth-key-1");
 
             var tmpFile= Path.GetTempFileName();
 
@@ -36,13 +36,13 @@ namespace TlsClient.Api.Tests
             File.Delete(tmpFile);
 
             response.Status.Should().Be(HttpStatusCode.OK);
-            fileLength.Should().Be(long.Parse(contentLength));
+            fileInfo.Exists.Should().BeTrue();
         }
 
         [Fact]
         public void Should_Send_Json()
         {
-            using var tlsClient = new ApiTlsClient(new Uri("http://127.0.0.1:8080"), "my-auth-key-1");
+            using var tlsClient = new ApiTlsClient(new Uri("http://127.0.0.1:5666"), "my-auth-key-1");
             var jsonBody = "{\"title\":\"foo\",\"body\":\"bar\",\"userId\":1}";
             var request = new Request()
             {
@@ -66,7 +66,7 @@ namespace TlsClient.Api.Tests
         [Fact]
         public void Should_Send_Form()
         {
-            using var tlsClient = new ApiTlsClient(new Uri("http://127.0.0.1:8080"), "my-auth-key-1");
+            using var tlsClient = new ApiTlsClient(new Uri("http://127.0.0.1:5666"), "my-auth-key-1");
             var request = new Request()
             {
                 RequestUrl = "https://postman-echo.com/post",
@@ -89,7 +89,7 @@ namespace TlsClient.Api.Tests
         [Fact]
         public async Task Should_Send_File()
         {
-            using var tlsClient = new ApiTlsClient(new Uri("http://127.0.0.1:8080"), "my-auth-key-1");
+            using var tlsClient = new ApiTlsClient(new Uri("http://127.0.0.1:5666"), "my-auth-key-1");
 
             var filePath = "testfile.txt";
             File.WriteAllText(filePath, "This is a test file.");

--- a/tests/TlsClient.Api.Tests/CookieTests.cs
+++ b/tests/TlsClient.Api.Tests/CookieTests.cs
@@ -18,7 +18,7 @@ namespace TlsClient.Api.Tests
         [Fact]
         public void Should_Include_Cookie()
         {
-            using var tlsClient = new ApiTlsClient(new Uri("http://127.0.0.1:8080"), "my-auth-key-1");
+            using var tlsClient = new ApiTlsClient(new Uri("http://127.0.0.1:5666"), "my-auth-key-1");
             tlsClient.Options.WithCustomCookieJar = true;
 
             var request = new Request()
@@ -37,7 +37,7 @@ namespace TlsClient.Api.Tests
         [Fact]
         public void Should_Keep_Cookie()
         {
-            using var tlsClient = new ApiTlsClient(new Uri("http://127.0.0.1:8080"), "my-auth-key-1");
+            using var tlsClient = new ApiTlsClient(new Uri("http://127.0.0.1:5666"), "my-auth-key-1");
             var request = new Request()
             {
                 RequestUrl = BaseURL + "/cookies/set?sessionid=123456",
@@ -57,7 +57,7 @@ namespace TlsClient.Api.Tests
         [Fact]
         public void Should_Not_Keep_Cookie_By_Request()
         {
-            using var tlsClient = new ApiTlsClient(new Uri("http://127.0.0.1:8080"), "my-auth-key-1");
+            using var tlsClient = new ApiTlsClient(new Uri("http://127.0.0.1:5666"), "my-auth-key-1");
             var request = new Request()
             {
                 RequestUrl = BaseURL + "/cookies/set?sessionid=123456",
@@ -77,7 +77,7 @@ namespace TlsClient.Api.Tests
         [Fact]
         public void Should_Not_Keep_Cookie_By_Client()
         {
-            using var tlsClient = new ApiTlsClient(new ApiTlsClientOptions(new Uri("http://127.0.0.1:8080"), "my-auth-key-1")
+            using var tlsClient = new ApiTlsClient(new ApiTlsClientOptions(new Uri("http://127.0.0.1:5666"), "my-auth-key-1")
             {
                 TlsClientIdentifier= TlsClientIdentifier.Chrome133,
                 WithoutCookieJar = true
@@ -99,7 +99,7 @@ namespace TlsClient.Api.Tests
         [Fact]
         public void Should_Include_Cookie_By_Header()
         {
-            using var tlsClient = new ApiTlsClient(new Uri("http://127.0.0.1:8080"), "my-auth-key-1");
+            using var tlsClient = new ApiTlsClient(new Uri("http://127.0.0.1:5666"), "my-auth-key-1");
             tlsClient.DefaultHeaders.Add("Cookie", new List<string> { "sessionid=123456" });
 
             var request = new Request()
@@ -114,7 +114,7 @@ namespace TlsClient.Api.Tests
         [Fact]
         public void Should_Get_Cookie()
         {
-            using var tlsClient = new ApiTlsClient(new Uri("http://127.0.0.1:8080"), "my-auth-key-1");
+            using var tlsClient = new ApiTlsClient(new Uri("http://127.0.0.1:5666"), "my-auth-key-1");
 
             var request = new Request()
             {

--- a/tests/TlsClient.Native.Tests/BodyTests.cs
+++ b/tests/TlsClient.Native.Tests/BodyTests.cs
@@ -16,7 +16,7 @@ namespace TlsClient.Core.Tests
     {
         static BodyTests()
         {
-            NativeTlsClient.Initialize("D:\\Tools\\tls-client-windows-64-1.13.1.dll");
+            NativeTlsClient.Initialize("D:\\Tools\\tls-client-windows-64-1.15.1.dll");
         }
 
         [Fact]
@@ -37,7 +37,7 @@ namespace TlsClient.Core.Tests
             File.Delete("avatar.png");
 
             response.Status.Should().Be(HttpStatusCode.OK);
-            fileLength.Should().Be(long.Parse(contentLength));
+            fileInfo.Exists.Should().BeTrue();
         }
 
         [Fact]

--- a/tests/TlsClient.Native.Tests/BuilderTests.cs
+++ b/tests/TlsClient.Native.Tests/BuilderTests.cs
@@ -17,7 +17,7 @@ namespace TlsClient.Core.Tests
     {
         static BuilderTests()
         {
-            NativeTlsClient.Initialize("D:\\Tools\\tls-client-windows-64-1.13.1.dll");
+            NativeTlsClient.Initialize("D:\\Tools\\tls-client-windows-64-1.15.1.dll");
         }
 
 

--- a/tests/TlsClient.Native.Tests/ClientTests.cs
+++ b/tests/TlsClient.Native.Tests/ClientTests.cs
@@ -10,7 +10,7 @@ namespace TlsClient.Core.Tests
     {
         static ClientTests()
         {
-            NativeTlsClient.Initialize("D:\\Tools\\tls-client-windows-64-1.13.1.dll");
+            NativeTlsClient.Initialize("D:\\Tools\\tls-client-windows-64-1.15.1.dll");
         }
 
         [Fact]

--- a/tests/TlsClient.Native.Tests/MethodTests.cs
+++ b/tests/TlsClient.Native.Tests/MethodTests.cs
@@ -9,7 +9,7 @@ namespace TlsClient.Core.Tests
         public static readonly string BaseURL = "https://httpbin.io";
         static MethodTests()
         {
-            NativeTlsClient.Initialize("D:\\Tools\\tls-client-windows-64-1.13.1.dll");
+            NativeTlsClient.Initialize("D:\\Tools\\tls-client-windows-64-1.15.1.dll");
         }
 
         [Fact]

--- a/tests/TlsClient.Native.Tests/PerformanceTests.cs
+++ b/tests/TlsClient.Native.Tests/PerformanceTests.cs
@@ -36,7 +36,7 @@ namespace TlsClient.Core.Tests
                 {
                     using var tlsClient = new NativeTlsClient(new TlsClientOptions
                     {
-                        TlsClientIdentifier = TlsClientIdentifier.Chrome132,
+                        TlsClientIdentifier = TlsClientIdentifier.Chrome146,
                         Timeout = TimeSpan.FromSeconds(10)
                     });
 
@@ -80,7 +80,7 @@ namespace TlsClient.Core.Tests
                 {
                     using var tlsClient = new NativeTlsClient(new TlsClientOptions
                     {
-                        TlsClientIdentifier = TlsClientIdentifier.Chrome132,
+                        TlsClientIdentifier = TlsClientIdentifier.Chrome146,
                         Timeout = TimeSpan.FromSeconds(10)
                     });
 

--- a/tests/TlsClient.Native.Tests/TlsTests.cs
+++ b/tests/TlsClient.Native.Tests/TlsTests.cs
@@ -37,7 +37,7 @@ namespace TlsClient.Core.Tests
             using var tlsClient = new NativeTlsClient(new TlsClientOptions()
             {
                 InsecureSkipVerify = true,
-                TlsClientIdentifier = TlsClientIdentifier.Chrome132,
+                TlsClientIdentifier = TlsClientIdentifier.Chrome146,
             });
             var request = new Request()
             {
@@ -53,7 +53,7 @@ namespace TlsClient.Core.Tests
             using var tlsClient = new NativeTlsClient(new TlsClientOptions()
             {
                 ForceHttp1 = true,
-                TlsClientIdentifier = TlsClientIdentifier.Chrome132,
+                TlsClientIdentifier = TlsClientIdentifier.Chrome146,
             });
             var request = new Request()
             {
@@ -69,7 +69,7 @@ namespace TlsClient.Core.Tests
         {
             using var tlsClient = new NativeTlsClient(new TlsClientOptions()
             {
-                TlsClientIdentifier = TlsClientIdentifier.Chrome132,
+                TlsClientIdentifier = TlsClientIdentifier.Chrome146,
             });
             var request = new Request()
             {


### PR DESCRIPTION
Changed default TlsClientIdentifier to Chrome146 and updated the default User-Agent. Added new identifiers for Chrome146, Brave146, SafariIos260, and Firefox148Psk; removed Chrome132. Updated test server port to 5666, switched file length checks to file existence checks in download tests, upgraded native DLL path to 1.15.1, and updated test profiles to use Chrome146.